### PR TITLE
Updated to newest XKNX api, added Docker environment and other feature enhancement (reopened)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3-alpine
 
 ENV LOGDIR="/var/log/knx2mqtt"
+ENV KNX_LOCAL_PORT=12399
 
 COPY . /app
 
@@ -16,5 +17,5 @@ RUN mkdir -p $LOGDIR
 # Remove default config file -> require mount
 RUN rm knx2mqtt.yaml
 
-EXPOSE 12399/udp
+EXPOSE $KNX_LOCAL_PORT/udp
 CMD ["/bin/sh", "-c", "touch $LOGDIR/.tmpfs && python3 bin/knx2mqtt"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3-alpine
 
 ENV LOGDIR="/var/log/knx2mqtt"
+ENV CONFIG_FILE="/config/knx2mqtt.yaml"
 ENV KNX_LOCAL_PORT=12399
 
 COPY . /app
@@ -18,4 +19,4 @@ RUN mkdir -p $LOGDIR
 RUN rm knx2mqtt.yaml
 
 EXPOSE $KNX_LOCAL_PORT/udp
-CMD ["/bin/sh", "-c", "touch $LOGDIR/.tmpfs && python3 bin/knx2mqtt"]
+CMD ["/bin/sh", "-c", "touch $LOGDIR/.tmpfs && python3 bin/knx2mqtt -c $CONFIG_FILE"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3-alpine
 
 ENV LOGDIR="/var/log/knx2mqtt"
+ENV LOGCONFIG_FILE="/config/logging.production.conf"
 ENV CONFIG_FILE="/config/knx2mqtt.yaml"
 ENV KNX_LOCAL_PORT=12399
 
@@ -13,10 +14,12 @@ RUN pip install -e knx2mqtt
 RUN apk del gcc musl-dev linux-headers
 
 # Logging
+RUN mkdir -p /config
+RUN mv logging*.conf /config
 RUN mkdir -p $LOGDIR
 
 # Remove default config file -> require mount
 RUN rm knx2mqtt.yaml
 
 EXPOSE $KNX_LOCAL_PORT/udp
-CMD ["/bin/sh", "-c", "touch $LOGDIR/.tmpfs && python3 bin/knx2mqtt -c $CONFIG_FILE"]
+CMD ["/bin/sh", "-c", "touch $LOGDIR/.tmpfs && python3 bin/knx2mqtt -c $CONFIG_FILE -l $LOGCONFIG_FILE"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3-alpine
+
+ENV LOGDIR="/var/log/knx2mqtt"
+
+COPY . /app
+
+WORKDIR /app
+RUN apk add --no-cache gcc musl-dev linux-headers
+RUN pip install -r requirements.txt
+RUN pip install -e knx2mqtt
+RUN apk del gcc musl-dev linux-headers
+
+# Logging
+RUN mkdir -p $LOGDIR
+
+# Remove default config file -> require mount
+RUN rm knx2mqtt.yaml
+
+CMD ["/bin/sh", "-c", "touch $LOGDIR/.tmpfs && python3 bin/knx2mqtt"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,5 @@ RUN mkdir -p $LOGDIR
 # Remove default config file -> require mount
 RUN rm knx2mqtt.yaml
 
+EXPOSE 12399/udp
 CMD ["/bin/sh", "-c", "touch $LOGDIR/.tmpfs && python3 bin/knx2mqtt"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,15 +8,16 @@ ENV KNX_LOCAL_PORT=12399
 COPY . /app
 
 WORKDIR /app
-RUN apk add --no-cache gcc musl-dev linux-headers
-RUN pip install -r requirements.txt
-RUN pip install -e knx2mqtt
-RUN apk del gcc musl-dev linux-headers
+RUN apk add --no-cache gcc musl-dev libffi-dev linux-headers \
+    && pip install -r requirements.txt \
+    && pip install -e knx2mqtt \
+    && apk del --purge gcc musl-dev libffi-dev linux-headers \
+    && rm -rf /var/cache/apk/*
 
 # Logging
-RUN mkdir -p /config
-RUN mv logging*.conf /config
-RUN mkdir -p $LOGDIR
+RUN mkdir -p /config \
+    && mv logging*.conf /config \
+    && mkdir -p $LOGDIR
 
 # Remove default config file -> require mount
 RUN rm knx2mqtt.yaml

--- a/README.md
+++ b/README.md
@@ -144,7 +144,15 @@ knx:
       local_port: 12399
       route_back: True
 ```
-The port `12399/udp` is exposed by the container.
+The port `12399/udp` is exposed by the container.  
+  
+You can also use the following environment variables:  
+`LOGDIR` path to log files.  
+`LOGCONFIG_FILE` path to configuration file for logging options (use `/config/logging.production.conf` for producation and `/config/logging.conf` for debugging).  
+`CONFIG_FILE` path to main knx2mqqt configuration file.  
+`KNX_LOCAL_PORT` default local UDP port used by knx2mqtt for KNX gateway communication.  
+  
+The default values are defined in the file `Dockerfile`.
 
 
 ### Publishing

--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 I've created this project as a replacement for the KNX integration of [HomeAssistant](https://home-assistant.io/) that worked not stable in my environment.
 
-It is quite simple and does what it's name says: It works as a bridge between KNX and MQTT tranlating messages between these in both directions.
+It is quite simple and does what it's name says: It works as a bridge between KNX and MQTT translating messages between these in both directions.
+It can also perfectly be used to route KNX messages between several KNX installations, e.g., if you have an indoor and an outdoor setup.
 
 ## Installation
 
 ### Native environment
-The installation required Python 3.7 (it should work with Python 3.5 and 3.6 as well) and `git`.
+The installation requires minimum Python 3.8 and `git`.
 
 I usually install my own services under `/opt/services`.
 So, it works out of the box, if you just do:

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ First, you need to configure your MQTT server.
 
 ```
 mqtt:
+  client_id: knx2mqtt
   host: your.mqtt-server.name
   port: 1883
   user: knx2mqtt
@@ -61,6 +62,7 @@ mqtt:
   topic: "home/bus/knx"
   qos: 0
   retain: true
+  keepalive: 60
 ```
 
 Usually, you only need to change the `host`, `user` and `password`.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ knx:
             gateway_port: 3671
             local_ip: '192.168.0.12'
             #local_port: 12399
-            #route_back: False
+            #route_back: false
 ```
 If you are going to use knx2mqtt in a container, check the related section for configuration details.
 

--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ First, you need to configure your MQTT server.
 
 ```
 mqtt:
-    host: your.mqtt-server.name
-    port: 1883
-    user: knx2mqtt
-    password: topsecret
-    topic: "home/bus/knx"
-    qos: 0
-    retain: true
+  host: your.mqtt-server.name
+  port: 1883
+  user: knx2mqtt
+  password: topsecret
+  topic: "home/bus/knx"
+  qos: 0
+  retain: true
 ```
 
 Usually, you only need to change the `host`, `user` and `password`.
@@ -74,21 +74,21 @@ Then you can configure your KNX bus topology.
 First, you need to configure your KNX gateway.
 ```
 knx:
-    general:
-        own_address: '15.15.249'
-        #address_format: long
-        #rate_limit: 200
-        #multicast_group: '224.0.23.12'
-        #multicast_port: 3671
-    connection:
-        #routing:
-            #local_ip: 192.168.0.12
-        tunneling:
-            gateway_ip: '192.168.0.11'
-            gateway_port: 3671
-            local_ip: '192.168.0.12'
-            #local_port: 12399
-            #route_back: false
+  general:
+    own_address: '15.15.249'
+    #address_format: long
+    #rate_limit: 200
+    #multicast_group: '224.0.23.12'
+    #multicast_port: 3671
+  connection:
+    #routing:
+      #local_ip: 192.168.0.12
+    tunneling:
+      gateway_ip: '192.168.0.11'
+      gateway_port: 3671
+      local_ip: '192.168.0.12'
+      #local_port: 12399
+      #route_back: false
 ```
 If you are going to use knx2mqtt in a container, check the related section for configuration details.
 
@@ -96,10 +96,10 @@ At the moment the bridge supports sensors and switches.
 
 ```
 knx:
-    sensors:
-    ...
-    switches:
-    ...
+  sensors:
+  ...
+  switches:
+  ...
 ```
 
 Each item (sensors and switches) need an `address` (the group address) and a `type`.
@@ -114,20 +114,20 @@ If `expose` is `true`, values published on MQTT will be sent as telegram to KNX.
 
 ```
 knx:
-    sensors:
-        - address: 0/0/1
-          type: DPTDate
-          expose: true
+  sensors:
+    - address: 0/0/1
+      type: DPTDate
+      expose: true
 ```
 
 If `subscribe` is `true`, the bridge works in bidirectional mode. Values from KNX are published to MQTT and vice versa.
 
 ```
 knx:
-    switches:
-        - address: 0/1/1
-          type: DPTBinary
-          subscribe: true
+  switches:
+    - address: 0/1/1
+      type: DPTBinary
+      subscribe: true
 ```
 
 #### KNX configuration for container
@@ -135,12 +135,12 @@ When running the app in a container, you need to configure the KNX library accor
 Set ‘route_back’ to True or use host network mode.
 ```
 knx:
-    connection:
-        tunneling:
-            gateway_ip: '192.168.0.11'
-            #gateway_port: 3671
-            local_port: 12399
-            route_back: True
+  connection:
+    tunneling:
+      gateway_ip: '192.168.0.11'
+      #gateway_port: 3671
+      local_port: 12399
+      route_back: True
 ```
 The port `12399/udp` is exposed by the container.
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ The `run` script expects an environment variable named `LOGDIR` where the logfil
 
 You can either run the container manually or use the provided `docker-compose` file.  
 
-The configuration file `knx2mqtt.yaml` must be mounted into the container at `/app/knx2mqtt.yaml`, otherwise the container won't start.
+The configuration file `knx2mqtt.yaml` must be mounted into the container at `/config/knx2mqtt.yaml`, otherwise the container won't start.
 
 Using plain docker:
 ```

--- a/bin/knx2mqtt
+++ b/bin/knx2mqtt
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!python3
 
 from knx2mqtt import config
 from knx2mqtt import daemon

--- a/bin/knx2mqtt
+++ b/bin/knx2mqtt
@@ -1,13 +1,26 @@
 #!python3
 
+import argparse
+
 from knx2mqtt import config
 from knx2mqtt import daemon
 
+
 def main():
+	# Parse command line arguments
+	parser = argparse.ArgumentParser(description='A KNX2MQTT Bridge allowing bidirectional telegram transfer')
+	parser.add_argument('-c', '--config', type=str, help='path to a knx2mqtt configuration file')
+	args = parser.parse_args()
+
+	# Convert args to user config
+	user_cfg = {}
+	if args.config:
+		user_cfg.update({'file': args.config})
+
+	# Setup app
 	cfg = config.Config()
-	cfg.read()
+	cfg.read(**user_cfg)
 	d = daemon.Daemon(cfg)
 	d.run()
 	
 main()
-

--- a/bin/knx2mqtt
+++ b/bin/knx2mqtt
@@ -10,16 +10,21 @@ def main():
 	# Parse command line arguments
 	parser = argparse.ArgumentParser(description='A KNX2MQTT Bridge allowing bidirectional telegram transfer')
 	parser.add_argument('-c', '--config', type=str, help='path to a knx2mqtt configuration file')
+	parser.add_argument('-l', '--logconfig', type=str, help='path to a logging configuration file')
 	args = parser.parse_args()
 
 	# Convert args to user config
 	user_cfg = {}
+	if args.logconfig:
+		user_cfg.update({'file': args.logconfig})
+
+	user_read_cfg = {}
 	if args.config:
-		user_cfg.update({'file': args.config})
+		user_read_cfg.update({'file': args.config})
 
 	# Setup app
-	cfg = config.Config()
-	cfg.read(**user_cfg)
+	cfg = config.Config(**user_cfg)
+	cfg.read(**user_read_cfg)
 	d = daemon.Daemon(cfg)
 	d.run()
 	

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,4 +8,4 @@ services:
     restart: 'unless-stopped'
     volumes:
       - /etc/localtime:/etc/localtime:ro
-      - ./knx2mqtt.yaml:/app/knx2mqtt.yaml
+      - ./knx2mqtt.yaml:/config/knx2mqtt.yaml

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,11 @@
+version: '3.8'
+
+services:
+  knx2mqtt:
+    build:
+      context: '.'
+    image: 'knx2mqtt'
+    restart: 'unless-stopped'
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - ./knx2mqtt.yaml:/app/knx2mqtt.yaml

--- a/install
+++ b/install
@@ -8,5 +8,5 @@
 python3 -m venv .
 
 . bin/activate
-pip install paho.mqtt pyyaml xknx
+pip install -r requirements.txt
 pip install -e knx2mqtt

--- a/knx2mqtt.yaml
+++ b/knx2mqtt.yaml
@@ -7,6 +7,21 @@ mqtt:
     qos: 0
     retain: true
 knx:
+    general:
+        own_address: '15.15.249'
+        #address_format: long
+        #rate_limit: 200
+        #multicast_group: '224.0.23.12'
+        #multicast_port: 3671
+    connection:
+        #routing:
+            #local_ip: 192.168.0.12
+        tunneling:
+            gateway_ip: '192.168.0.11'
+            gateway_port: 3671
+            local_ip: '192.168.0.12'
+            #local_port: 12399
+            #route_back: True
     sensors:
         - address: 0/0/1
           type: DPTDate

--- a/knx2mqtt.yaml
+++ b/knx2mqtt.yaml
@@ -1,4 +1,5 @@
 mqtt:
+  client_id: knx2mqtt
   host: your.mqtt-server.name
   port: 1883
   user: knx2mqtt
@@ -6,6 +7,7 @@ mqtt:
   topic: "home/bus/knx"
   qos: 0
   retain: true
+  keepalive: 60
 knx:
   general:
     own_address: '15.15.249'

--- a/knx2mqtt.yaml
+++ b/knx2mqtt.yaml
@@ -1,47 +1,47 @@
 mqtt:
-    host: your.mqtt-server.name
-    port: 1883
-    user: knx2mqtt
-    password: topsecret
-    topic: "home/bus/knx"
-    qos: 0
-    retain: true
+  host: your.mqtt-server.name
+  port: 1883
+  user: knx2mqtt
+  password: topsecret
+  topic: "home/bus/knx"
+  qos: 0
+  retain: true
 knx:
-    general:
-        own_address: '15.15.249'
-        #address_format: long
-        #rate_limit: 200
-        #multicast_group: '224.0.23.12'
-        #multicast_port: 3671
-    connection:
-        #routing:
-            #local_ip: 192.168.0.12
-        tunneling:
-            gateway_ip: '192.168.0.11'
-            gateway_port: 3671
-            local_ip: '192.168.0.12'
-            #local_port: 12399
-            #route_back: True
-    sensors:
-        - address: 0/0/1
-          type: DPTDate
-          expose: true
-        - address: 0/0/2
-          type: DPTTime
-          expose: true
-        - address: 0/0/3
-          type: DPTDateTime
-          expose: true
-        - address: 0/0/4
-          type: DPTTemperature
-          expose: true
-        - address: 1/0/0
-          type: DPTTemperature
-        - address: 1/0/1
-          type: DPTHumidity
-        - address: 1/0/2
-          type: DPTPartsPerMillion
-    switches:
-        - address: 0/1/1
-          type: DPTBinary
-          subscribe: true
+  general:
+    own_address: '15.15.249'
+    #address_format: long
+    #rate_limit: 200
+    #multicast_group: '224.0.23.12'
+    #multicast_port: 3671
+  connection:
+    #routing:
+      #local_ip: 192.168.0.12
+    tunneling:
+      gateway_ip: '192.168.0.11'
+      gateway_port: 3671
+      local_ip: '192.168.0.12'
+      #local_port: 12399
+      #route_back: false
+  sensors:
+    - address: 0/0/1
+      type: DPTDate
+      expose: true
+    - address: 0/0/2
+      type: DPTTime
+      expose: true
+    - address: 0/0/3
+      type: DPTDateTime
+      expose: true
+    - address: 0/0/4
+      type: DPTTemperature
+      expose: true
+    - address: 1/0/0
+      type: DPTTemperature
+    - address: 1/0/1
+      type: DPTHumidity
+    - address: 1/0/2
+      type: DPTPartsPerMillion
+  switches:
+    - address: 0/1/1
+      type: DPTBinary
+      subscribe: true

--- a/knx2mqtt/knx2mqtt/config.py
+++ b/knx2mqtt/knx2mqtt/config.py
@@ -2,14 +2,15 @@ import yaml
 import logging
 import logging.config
 
+
 class Config:
 	"""Class for parsing knx2mqtt.yaml."""
 	
 	def __init__(self):
 		"""Initialize Config class."""
-#		logging.config.dictConfig(yaml.load('logging.conf'))
+#		logging.config.dictConfig(yaml.load('logging.conf', Loader=yaml.SafeLoader))
 		with open('logging.conf') as f:
-			D = yaml.load(f)
+			D = yaml.load(f, Loader=yaml.SafeLoader)
 			D.setdefault('version', 1)
 			logging.config.dictConfig(D)
 		self._mqtt = {}
@@ -21,7 +22,7 @@ class Config:
 		logging.debug("Reading %s", file)
 		try:
 			with open(file, 'r') as filehandle:
-				config = yaml.load(filehandle)
+				config = yaml.load(filehandle, Loader=yaml.SafeLoader)
 				self._parse_mqtt(config)
 				self._parse_knx(config)
 		except FileNotFoundError as ex:

--- a/knx2mqtt/knx2mqtt/config.py
+++ b/knx2mqtt/knx2mqtt/config.py
@@ -26,7 +26,8 @@ class Config:
 				self._parse_mqtt(config)
 				self._parse_knx(config)
 		except FileNotFoundError as ex:
-			logging.error("Error while reading %s: %s", file, ex)
+			logging.error("Configuration file %s not found: %s", file, ex)
+			exit(ex.errno)
 
 
 	def _parse_mqtt(self, config):

--- a/knx2mqtt/knx2mqtt/config.py
+++ b/knx2mqtt/knx2mqtt/config.py
@@ -40,7 +40,7 @@ class Config:
 			self._mqtt = config["mqtt"]
 
 			if not "client_id" in self._mqtt:
-				self._mqtt["port"] = "knx2mqtt"
+				self._mqtt["client_id"] = "knx2mqtt"
 			if not "host" in self._mqtt:
 				raise ValueError("MQTT host not set")
 			if not "port" in self._mqtt:
@@ -48,7 +48,7 @@ class Config:
 			if not "user" in self._mqtt:
 				self._mqtt["user"] = ""
 			if not "password" in self._mqtt:
-				self._mqtt["port"] = ""
+				self._mqtt["password"] = ""
 			if not "topic" in self._mqtt:
 				raise ValueError("MQTT topic not set")
 			if not "qos" in self._mqtt:

--- a/knx2mqtt/knx2mqtt/config.py
+++ b/knx2mqtt/knx2mqtt/config.py
@@ -6,15 +6,19 @@ import logging.config
 class Config:
 	"""Class for parsing knx2mqtt.yaml."""
 	
-	def __init__(self):
+	def __init__(self, file='logging.conf'):
 		"""Initialize Config class."""
-#		logging.config.dictConfig(yaml.load('logging.conf', Loader=yaml.SafeLoader))
-		with open('logging.conf') as f:
-			D = yaml.load(f, Loader=yaml.SafeLoader)
-			D.setdefault('version', 1)
-			logging.config.dictConfig(D)
-		self._mqtt = {}
-		self._knx = {}
+		logging.debug("Reading %s", file)
+		try:
+			with open(file, 'r') as f:
+				D = yaml.load(f, Loader=yaml.SafeLoader)
+				D.setdefault('version', 1)
+				logging.config.dictConfig(D)
+			self._mqtt = {}
+			self._knx = {}
+		except FileNotFoundError as ex:
+			logging.error("Logging configuration file %s not found: %s", file, ex)
+			exit(ex.errno)
 	
 	
 	def read(self, file='knx2mqtt.yaml'):

--- a/knx2mqtt/knx2mqtt/config.py
+++ b/knx2mqtt/knx2mqtt/config.py
@@ -34,32 +34,49 @@ class Config:
 		"""Parse the mqtt section of knx2mqtt.yaml."""
 		if "mqtt" in config:
 			self._mqtt = config["mqtt"]
-		if not "host" in self._mqtt:
-			raise ValueError("MQTT host not set")
-		if not "port" in self._mqtt:
-			raise ValueError("MQTT port not set")
-		if not "user" in self._mqtt:
-			raise ValueError("MQTT user not set")
-		if not "password" in self._mqtt:
-			raise ValueError("MQTT password not set")
-		if not "topic" in self._mqtt:
-			raise ValueError("MQTT topic not set")
-		if not "qos" in self._mqtt:
-			self._mqtt["qos"] = 0
-		if not "retain" in self._mqtt:
-			self._mqtt["retain"] = False
+
+			if not "host" in self._mqtt:
+				raise ValueError("MQTT host not set")
+			if not "port" in self._mqtt:
+				raise ValueError("MQTT port not set")
+			if not "user" in self._mqtt:
+				raise ValueError("MQTT user not set")
+			if not "password" in self._mqtt:
+				raise ValueError("MQTT password not set")
+			if not "topic" in self._mqtt:
+				raise ValueError("MQTT topic not set")
+			if not "qos" in self._mqtt:
+				self._mqtt["qos"] = 0
+			if not "retain" in self._mqtt:
+				self._mqtt["retain"] = False
+
+		else:
+			logging.error("MQTT configuration not found in configuration file.")
+			exit(1)
 
 
 	def _parse_knx(self, config):
 		"""Parse the knx section of knx2mqtt.yaml."""
 		if "knx" in config:
 			self._knx = config["knx"]
-		for item in self._knx["sensors"]:
-			if not "address" in item:
-				raise ValueError("Missing address for KNX sensor")
-		for item in self._knx["switches"]:
-			if not "address" in item:
-				raise ValueError("Missing address for KNX switch")
+
+			if "sensors" in self._knx:
+				for item in self._knx["sensors"]:
+					if not "address" in item:
+						raise ValueError("Missing address for KNX sensor")
+			else:
+				self._knx["sensors"] = []
+
+			if "switches" in self._knx:
+				for item in self._knx["switches"]:
+					if not "address" in item:
+						raise ValueError("Missing address for KNX switch")
+			else:
+				self._knx["switches"] = []
+
+		else:
+			logging.error("KNX configuration not found in configuration file.")
+			exit(1)
 
 
 	def mqtt(self):

--- a/knx2mqtt/knx2mqtt/config.py
+++ b/knx2mqtt/knx2mqtt/config.py
@@ -39,20 +39,24 @@ class Config:
 		if "mqtt" in config:
 			self._mqtt = config["mqtt"]
 
+			if not "client_id" in self._mqtt:
+				self._mqtt["port"] = "knx2mqtt"
 			if not "host" in self._mqtt:
 				raise ValueError("MQTT host not set")
 			if not "port" in self._mqtt:
-				raise ValueError("MQTT port not set")
+				self._mqtt["port"] = 1883
 			if not "user" in self._mqtt:
-				raise ValueError("MQTT user not set")
+				self._mqtt["user"] = ""
 			if not "password" in self._mqtt:
-				raise ValueError("MQTT password not set")
+				self._mqtt["port"] = ""
 			if not "topic" in self._mqtt:
 				raise ValueError("MQTT topic not set")
 			if not "qos" in self._mqtt:
 				self._mqtt["qos"] = 0
 			if not "retain" in self._mqtt:
 				self._mqtt["retain"] = False
+			if not "keepalive" in self._mqtt:
+				self._mqtt["keepalive"] = 60
 
 		else:
 			logging.error("MQTT configuration not found in configuration file.")

--- a/knx2mqtt/knx2mqtt/knx.py
+++ b/knx2mqtt/knx2mqtt/knx.py
@@ -54,6 +54,7 @@ class Knx:
 
 		# Setup XKNX
 		self._xknx = XKNX(**gen_params, daemon_mode=True, connection_config=conn_config)
+		logging.info("XKNX instance (version %s) for connection to KNX gateway %s created." % (self._xknx.version, conn_config.gateway_ip))
 
 
 	def set_telegram_cb(self, cb):

--- a/knx2mqtt/knx2mqtt/knx.py
+++ b/knx2mqtt/knx2mqtt/knx.py
@@ -81,7 +81,7 @@ class Knx:
             payload = GroupValueWrite(payload),
         )
 
-		logging.debug(telegram)
+		logging.debug("Publishing telegram: {0}".format(telegram))
 
 		if self._xknx.started:
 #			loop = asyncio.new_event_loop()

--- a/knx2mqtt/knx2mqtt/knx.py
+++ b/knx2mqtt/knx2mqtt/knx.py
@@ -1,5 +1,6 @@
 import logging
 import asyncio
+import socket
 
 from xknx import XKNX
 from xknx.io import ConnectionConfig, ConnectionType
@@ -44,6 +45,9 @@ class Knx:
 			elif 'tunneling' in self._config['connection']:
 				conn_type = ConnectionType.TUNNELING
 				conn_params = self._config['connection']['tunneling']
+
+				# Resolve gateway ip, if needed
+				conn_params['gateway_ip'] = socket.gethostbyname(conn_params['gateway_ip'])
 				
 		conn_config = ConnectionConfig(**conn_params, connection_type=conn_type)
 		logging.debug("KNX connection type is {0}".format(conn_type))

--- a/knx2mqtt/knx2mqtt/knx.py
+++ b/knx2mqtt/knx2mqtt/knx.py
@@ -54,7 +54,7 @@ class Knx:
 
 		# Setup XKNX
 		self._xknx = XKNX(**gen_params, daemon_mode=True, connection_config=conn_config)
-		logging.info("XKNX instance (version %s) for connection to KNX gateway %s created." % (self._xknx.version, conn_config.gateway_ip))
+		logging.info("XKNX instance (version %s) for connection to KNX gateway %s created. KNX address of this instance is %s." % (self._xknx.version, conn_config.gateway_ip, self._xknx.own_address))
 
 
 	def set_telegram_cb(self, cb):

--- a/knx2mqtt/knx2mqtt/knx2mqtt.py
+++ b/knx2mqtt/knx2mqtt/knx2mqtt.py
@@ -16,23 +16,24 @@ class knx2mqtt:
 	async def callback(self, telegram):
 		try:
 			logging.info("KNX2MQTT {}".format(telegram))
-			group_address = str(telegram.group_address)
-			payload = telegram.payload
+			group_address = str(telegram.destination_address)
+			payload = telegram.payload.value
 
 			dpttype = self._knx.get_dpttype(group_address)
+			dpttype_auto = payload.__class__.__name__
 
 			if dpttype is None:
 				logging.info("No DPTType found for address {0}".format(group_address))
 				return True
 			elif dpttype == "DPTBinary":
-				logging.debug("{0} {1}".format(group_address, dpttype))
+				logging.debug("group address: {0}; dpttype by user: {1}; dpttype detected: {2};".format(group_address, dpttype, dpttype_auto))
 				value = payload.value
 			else:
-				logging.debug("{0} {1}".format(group_address, dpttype))
+				logging.debug("group address: {0}; dpttype by user: {1}; dpttype detected: {2};".format(group_address, dpttype, dpttype_auto))
 				dptcls = getattr(importlib.import_module(XKNX_DPT_MODULE_STR), dpttype)
 				value = dptcls.from_knx(payload.value)
 
-			logging.debug("{0} {1}".format(payload, value))
+			logging.debug("payload: {0}; value: {1};".format(payload, value))
 
 			if not self._states.is_state(group_address, value):
 				self._states.set_state(group_address, value)

--- a/knx2mqtt/knx2mqtt/knx2mqtt.py
+++ b/knx2mqtt/knx2mqtt/knx2mqtt.py
@@ -1,6 +1,8 @@
 import traceback
 import logging
 import importlib
+XKNX_DPT_MODULE_STR = "xknx.dpt"
+
 
 class knx2mqtt:
 
@@ -27,7 +29,7 @@ class knx2mqtt:
 				value = payload.value
 			else:
 				logging.debug("{0} {1}".format(group_address, dpttype))
-				dptcls = getattr(importlib.import_module("xknx.knx"), dpttype)
+				dptcls = getattr(importlib.import_module(XKNX_DPT_MODULE_STR), dpttype)
 				value = dptcls.from_knx(payload.value)
 
 			logging.debug("{0} {1}".format(payload, value))

--- a/knx2mqtt/knx2mqtt/mqtt.py
+++ b/knx2mqtt/knx2mqtt/mqtt.py
@@ -9,8 +9,9 @@ class Mqtt:
 
 
 	def connect(self):
-		self._client = mqtt.Client()
-		self._client.username_pw_set(self._config['user'], self._config['password'])
+		self._client = mqtt.Client(self._config['client_id'])
+		if self._config['user'] or self._config['password']:
+			self._client.username_pw_set(self._config['user'], self._config['password'])
 
 
 	def disconnect(self):
@@ -45,5 +46,5 @@ class Mqtt:
 
 
 	def run(self):
-		self._client.connect(self._config['host'], self._config['port'])
+		self._client.connect(self._config['host'], self._config['port'], keepalive=self._config['keepalive'])
 		self._client.loop_start()

--- a/knx2mqtt/knx2mqtt/mqtt2knx.py
+++ b/knx2mqtt/knx2mqtt/mqtt2knx.py
@@ -6,6 +6,7 @@ from xknx.dpt import DPTArray, DPTBinary
 from xknx.telegram import GroupAddress
 XKNX_DPT_MODULE_STR = "xknx.dpt"
 
+
 class mqtt2knx:
 
 	def __init__(self, knx, mqtt, states):
@@ -54,6 +55,7 @@ class mqtt2knx:
 
 		except Exception as e:
 			logging.error(traceback.format_exc())
+
 
 	def on_connect(self, client, userdata, flags, rc):
 		try:

--- a/knx2mqtt/knx2mqtt/mqtt2knx.py
+++ b/knx2mqtt/knx2mqtt/mqtt2knx.py
@@ -2,7 +2,9 @@ import traceback
 import logging
 import importlib
 
-from xknx.knx import GroupAddress, DPTBinary, DPTArray
+from xknx.dpt import DPTArray, DPTBinary
+from xknx.telegram import GroupAddress
+XKNX_DPT_MODULE_STR = "xknx.dpt"
 
 class mqtt2knx:
 
@@ -39,7 +41,7 @@ class mqtt2knx:
 				elif dpttype == "DPTBinary":
 					value = DPTBinary(int(payload))
 				else:
-					dptcls = getattr(importlib.import_module("xknx.knx"), dpttype)
+					dptcls = getattr(importlib.import_module(XKNX_DPT_MODULE_STR), dpttype)
 					value = DPTArray(dptcls.to_knx(payload))
 
 				group_address = GroupAddress(address)

--- a/knx2mqtt/setup.py
+++ b/knx2mqtt/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
   
 setup(name='knx2mqtt',
-      version='0.1',
+      version='0.2',
       description='KNX 2 MQTT bridge',
       url='https://github.com/gbeine/knx2mqtt',
       author='Gerrit Beine',

--- a/logging.production.conf
+++ b/logging.production.conf
@@ -1,0 +1,23 @@
+formatters:
+    simpleFormater:
+        format: '%(asctime)s - %(name)s - %(levelname)s: %(message)s'
+        datefmt: '%Y/%m/%d %H:%M:%S'
+
+handlers:
+    console:
+        class: logging.StreamHandler
+        formatter: simpleFormater
+        level: INFO
+        stream: ext://sys.stdout
+
+loggers:
+    clogger:
+        level: INFO
+        handlers: [console]
+    xknx.knx:
+        level: INFO
+        handlers: [console]
+
+root:
+    level: INFO
+    handlers: [console]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+# Python requirements
+paho.mqtt
+pyyaml
+xknx

--- a/xknx.yaml
+++ b/xknx.yaml
@@ -1,7 +1,0 @@
-general:
-    own_address: '15.15.249'
-connection:
-    tunneling:
-        gateway_ip: 192.168.0.11
-        gateway_port: 3671
-        local_ip: 192.168.0.12


### PR DESCRIPTION
(this PR replaces PR #2 due to change of source branch name)
# Major changes

- Updated the use of XKNX to work with the newest version. This requires min. Python 3.8.
- Added Dockerfile and docker-compose.yaml to build and use knx2mqtt in a containered environment
- Path to configuration files is now configureable using command line parameters
- Some MQTT settings (like username and password) are now optional, if not necessarily needed
- Changed README accordingly

# Breaking changes
- Minimum Python3 version requirement changed to 3.8
- Support for xknx.yaml configuration file was removed by XKNX. Moved settings to knx section in knx2mqtt.yaml